### PR TITLE
[2.0] Display <button> out of the screen

### DIFF
--- a/Resources/public/css/slick-slider.scss
+++ b/Resources/public/css/slick-slider.scss
@@ -61,7 +61,7 @@
             width: 10px;
             height: 10px;
             margin: 0 2px;
-            text-indent: -999px;
+            text-indent: -4000px;
             border: 1px solid white;
             border-radius: 10px;
             cursor: pointer;


### PR DESCRIPTION
With a QHD resolution, buttons are visible:

![capture d ecran de 2018-02-05 14-57-59_](https://user-images.githubusercontent.com/2071331/35808663-cec14b18-0a86-11e8-9ec0-2baacfa2cf7f.png)

This PR moves buttons out of sight.

Same as #29.