### PR TITLE
Fix form to show correct advanced fields

### DIFF
--- a/Form/WidgetSliderItemType.php
+++ b/Form/WidgetSliderItemType.php
@@ -33,6 +33,9 @@ class WidgetSliderItemType extends WidgetType
                 'attr' => [
                     'class' => 'vic-position',
                 ],
+            ])
+            ->add('image', MediaType::class, [
+                'label' => 'form.slideritem.image.label',
             ]);
 
         if ($options['mode'] === Widget::MODE_STATIC) {
@@ -89,7 +92,7 @@ class WidgetSliderItemType extends WidgetType
      */
     private function manageAdvancedMode(FormInterface $form, $hasAdvancedField)
     {
-        if (!$hasAdvancedField) {
+        if ($hasAdvancedField) {
             $form
                 ->add('title', null, [
                     'label'          => 'form.slideritem.title.label',
@@ -106,9 +109,6 @@ class WidgetSliderItemType extends WidgetType
                 ->add('linkLabel', null, [
                     'label'          => 'form.slideritem.linkLabel.label',
                     'vic_help_block' => 'form.slideritem.deprecated',
-                ])
-                ->add('image', MediaType::class, [
-                    'label' => 'form.slideritem.image.label',
                 ]);
         }
     }

--- a/Form/WidgetSliderType.php
+++ b/Form/WidgetSliderType.php
@@ -82,8 +82,8 @@ class WidgetSliderType extends WidgetType
                 'attr'          => [
                     'id' => ($options['mode'] === Widget::MODE_STATIC) ? 'static' : $options['businessEntityId'],
                 ],
-                'options'       => [
-                    'mode'             => $options['mode'],
+                'entry_options' => [
+                    'mode' => $options['mode'],
                 ],
             ]);
     }

--- a/Resources/views/form.html.twig
+++ b/Resources/views/form.html.twig
@@ -42,7 +42,7 @@
         </div>
 
         <div class="vic-col-sm-12 vic-col-md-6 vic-col-lg-4">
-            <a href="#" onclick='addItemStaticForm("", {{ quantum }})' class="vic-btn vic-btn-add" class="vic-btn vic-btn-add add-request-block">{{ 'widget.form.WidgetListingItemType.addItem.label'|trans({}, 'victoire') }}</a>
+            <a href="#" onclick='addItemStaticForm("", {{ widget.quantum }})' class="vic-btn vic-btn-add" class="vic-btn vic-btn-add add-request-block">{{ 'widget.form.WidgetListingItemType.addItem.label'|trans({}, 'victoire') }}</a>
         </div>
 
         <div class="vic-col-sm-12">


### PR DESCRIPTION
Replace **option** key in form type by **entry_options** since it does not exist in Symfony 3.X to fix display of the edit modal
Add image field on simple mode
Add other fields on advanced mode