### PR TITLE
Fix Javascript syntax error

### DIFF
--- a/Resources/views/form.html.twig
+++ b/Resources/views/form.html.twig
@@ -67,12 +67,11 @@
             items: "> li",
             opacity: 0.5,
             stop: function(event, ui){
-		setPositionValues();
-                });
+                setPositionValues();
             }
         });
 
-	var setPositionValues = function() {
+        var setPositionValues = function() {
             var inputs = $vic('.vic-position');
             inputs.each(function(index){
                 $(this).val(index);


### PR DESCRIPTION
Fix typo in #36: `inputs.each(function(index){` was removed but not the closing parenthesis `});`.